### PR TITLE
Don't rely on async.el being in load-path.

### DIFF
--- a/async.el
+++ b/async.el
@@ -268,8 +268,7 @@ returns nil.  It can still be useful, however, as an argument to
                        (expand-file-name invocation-name
                                          invocation-directory))
               ,finish-func
-              "-Q" "-l" ,(funcall (symbol-function 'find-library-name)
-                                  "async")
+              "-Q" "-l" ,(symbol-file 'async-batch-invoke 'defun)
               "-batch" "-f" "async-batch-invoke"
               (if async-send-over-pipe
                   "<none>"


### PR DESCRIPTION
This uses "symbol-file" instead of "find-library-name" to figure out
where async.el is. This should work even if async.el was loaded without adding
its directory to the load-path.

Fixes #15.
