### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.elc
+*~
+async-autoloads.el


### PR DESCRIPTION
It will avoid tracking compilation files like *.elc and autoloads.