### PR TITLE
Choose coding system based on environment

### DIFF
--- a/async.el
+++ b/async.el
@@ -121,9 +121,9 @@ as follows:
 
 (defun async--receive-sexp (&optional stream)
   (let ((sexp (decode-coding-string (base64-decode-string
-                                     (read stream)) 'utf-8-unix))
+                                     (read stream)) 'utf-8-auto))
 	;; Parent expects UTF-8 encoded text.
-	(coding-system-for-write 'utf-8-unix))
+	(coding-system-for-write 'utf-8-auto))
     (if async-debug
         (message "Received sexp {{{%s}}}" (pp-to-string sexp)))
     (setq sexp (read sexp))
@@ -138,7 +138,7 @@ as follows:
 	(print-circle t))
     (prin1 sexp (current-buffer))
     ;; Just in case the string we're sending might contain EOF
-    (encode-coding-region (point-min) (point-max) 'utf-8-unix)
+    (encode-coding-region (point-min) (point-max) 'utf-8-auto)
     (base64-encode-region (point-min) (point-max) t)
     (goto-char (point-min)) (insert ?\")
     (goto-char (point-max)) (insert ?\" ?\n)))
@@ -154,7 +154,7 @@ as follows:
   "Called from the child Emacs process' command-line."
   ;; Make sure 'message' and 'prin1' encode stuff in UTF-8, as parent
   ;; process expects.
-  (let ((coding-system-for-write 'utf-8-unix))
+  (let ((coding-system-for-write 'utf-8-auto))
     (setq async-in-child-emacs t
 	  debug-on-error async-debug)
     (if debug-on-error
@@ -287,7 +287,7 @@ returns nil.  It can still be useful, however, as an argument to
 `async-ready' or `async-wait'."
   (let ((sexp start-func)
 	;; Subordinate Emacs will send text encoded in UTF-8.
-	(coding-system-for-read 'utf-8-unix))
+	(coding-system-for-read 'utf-8-auto))
     (setq async--procvar
           (async-start-process
            "emacs" (file-truename


### PR DESCRIPTION
Before this change, the coding system was hardcoded to `utf-8-unix`.
This change sets the coding system to `utf-8-auto`, which can handle
Windows-style newlines (i.e., `\r\n`).

Example:

    #+BEGIN_SRC emacs-lisp :results output
      (defun test-decoding (coding-system)
        (let ((sexp (decode-coding-string (base64-decode-string
                                           (base64-encode-string "line
    1\r\nline 2")) coding-system))
              (coding-system-for-write coding-system))
          (print (format "With coding system `%s`: {{{%s}}}" coding-system
    (pp-to-string sexp)))))

      (test-decoding 'utf-8-unix) ;; treats \r as a separate newline
      (test-decoding 'utf-8-dos)  ;; treats \r\n as a single newline
      (test-decoding 'utf-8-auto) ;; treats \r\n as a single newline
    #+END_SRC

    #+RESULTS:
    :
    : "With coding system `utf-8-unix`: {{{\"line 1
    \\nline 2\"}}}"
    :
    : "With coding system `utf-8-dos`: {{{\"line 1\\nline 2\"}}}"
    :
    : "With coding system `utf-8-auto`: {{{\"line 1\\nline 2\"}}}"

See https://github.com/jwiegley/emacs-async/issues/93 for more context.