### PR TITLE
Fix error from reverting to nonexistent directories

### DIFF
--- a/dired-async.el
+++ b/dired-async.el
@@ -162,7 +162,9 @@ Should take same args as `message'."
            (when dired-buffers
              (cl-loop for (_f . b) in dired-buffers
                       when (buffer-live-p b)
-                      do (with-current-buffer b (revert-buffer nil t))))
+                      do (with-current-buffer b
+                           (when (file-exists-p default-directory)
+                             (revert-buffer nil t)))))
            ;; Finally send the success message.
            (funcall dired-async-message-function
                     "Asynchronous %s of %s on %s file%s done"

--- a/dired-async.el
+++ b/dired-async.el
@@ -163,7 +163,8 @@ Should take same args as `message'."
              (cl-loop for (_f . b) in dired-buffers
                       when (buffer-live-p b)
                       do (with-current-buffer b
-                           (when (file-exists-p default-directory)
+                         (when (and (not (file-remote-p default-directory nil t))
+                                    (file-exists-p default-directory))
                              (revert-buffer nil t)))))
            ;; Finally send the success message.
            (funcall dired-async-message-function


### PR DESCRIPTION
when a dired buffer exists for a directory that has been deleted, dired-async's callback will throw an error. This is a simple fix for that.