### PR TITLE
fix package-lint/check-doc/byte-compiler warnings

### DIFF
--- a/async-pkg.el
+++ b/async-pkg.el
@@ -1,7 +1,7 @@
 ;;; async-pkg.el --- Generated package description from async.el
 (define-package "async" "1.9.4"
   "Asynchronous processing in Emacs"
-  'nil
+  '((emacs "24.3"))
   :url "https://github.com/jwiegley/emacs-async"
   :keywords '("async"))
 

--- a/async.el
+++ b/async.el
@@ -1,13 +1,13 @@
-;;; async.el --- Asynchronous processing in Emacs -*- lexical-binding: t -*-
+;;; async.el --- Asynchronous processing  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2012-2016 Free Software Foundation, Inc.
 
 ;; Author: John Wiegley <jwiegley@gmail.com>
 ;; Created: 18 Jun 2012
 ;; Version: 1.9.4
-
-;; Keywords: async
-;; X-URL: https://github.com/jwiegley/emacs-async
+;; Package-Requires: ((emacs "24.3"))
+;; Keywords: convenience async
+;; URL: https://github.com/jwiegley/emacs-async
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as
@@ -92,7 +92,7 @@ is returned unmodified."
 
 It sets the value for every variable matching INCLUDE-REGEXP and
 also PREDICATE.  It will not perform injection for any variable
-matching EXCLUDE-REGEXP (if present) or representing a syntax-table
+matching EXCLUDE-REGEXP (if present) or representing a `syntax-table'
 i.e. ending by \"-syntax-table\".
 When NOPROPS is non nil it tries to strip out text properties of each
 variable's value with `async-variables-noprops-function'.
@@ -206,7 +206,7 @@ It is intended to be used as follows:
     (process-send-region process (point-min) (point-max))))
 
 (defun async-batch-invoke ()
-  "Called from the child Emacs process' command-line."
+  "Called from the child Emacs process' command line."
   ;; Make sure 'message' and 'prin1' encode stuff in UTF-8, as parent
   ;; process expects.
   (let ((coding-system-for-write 'utf-8-auto))
@@ -252,7 +252,7 @@ its FINISH-FUNC is nil."
          #'identity async-callback-value (current-buffer))))))
 
 (defun async-message-p (value)
-  "Return true of VALUE is an async.el message packet."
+  "Return non-nil of VALUE is an async.el message packet."
   (and (listp value)
        (plist-get value :async-message)))
 
@@ -270,7 +270,7 @@ its FINISH-FUNC is nil."
 
 ;;;###autoload
 (defun async-start-process (name program finish-func &rest program-args)
-  "Start the executable PROGRAM asynchronously.  See `async-start'.
+  "Start the executable PROGRAM asynchronously named NAME.  See `async-start'.
 PROGRAM is passed PROGRAM-ARGS, calling FINISH-FUNC with the
 process object when done.  If FINISH-FUNC is nil, the future
 object will return the process object when the program is


### PR DESCRIPTION
Hi!
I found this package and I fix flycheck warnings for my first contribution step!

### before

``` emacs-lisp
 async.el     1   1 warning         Including "Emacs" in the package summary is usually redundant. (emacs-lisp-package)
 async.el     1   1 error           Package should have a Homepage or URL header. (emacs-lisp-package)
 async.el     1  55 warning         You should depend on (emacs "24") if you need lexical-binding. (emacs-lisp-package)
 async.el     9   4 warning         You should include standard keywords: see the variable `finder-known-keywords'. (emacs-lisp-package)
 async.el    34  30 error           You should depend on (emacs "24.3") or the cl-lib package if you need `cl-lib'. (emacs-lisp-package)
 async.el    63  11 error           You should depend on (emacs "24.3") or the cl-lib package if you need `cl-loop'. (emacs-lisp-package)
 async.el    95     warning         Lisp symbol ‘syntax-table’ should appear in quotes (emacs-lisp-checkdoc)
 async.el   140     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 async.el   154     warning         Argument ‘proc’ should appear (as PROC) in the doc string (emacs-lisp-checkdoc)
 async.el   178     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 async.el   190     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 async.el   202     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 async.el   209     warning         Lisp symbol ‘command-line’ should appear in quotes (emacs-lisp-checkdoc)
 async.el   255     warning         "true" should usually be "non-nil" (emacs-lisp-checkdoc)
 async.el   260     warning         Argument ‘args’ should appear (as ARGS) in the doc string (emacs-lisp-checkdoc)
 async.el   273     warning         Argument ‘name’ should appear (as NAME) in the doc string (emacs-lisp-checkdoc)
 async.el   290     warning         Name emacs should appear capitalized as Emacs (emacs-lisp-checkdoc)
 async.el   371     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 async.el   380     warning         Argument ‘bindings’ should appear (as BINDINGS) in the doc string (emacs-lisp-checkdoc)
 async.el   397  18 error           You should depend on (emacs "24.1") if you need `pcase'. (emacs-lisp-package)
```

### after

``` emacs-lisp
 async.el   140     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 async.el   154     warning         Argument ‘proc’ should appear (as PROC) in the doc string (emacs-lisp-checkdoc)
 async.el   178     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 async.el   190     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 async.el   202     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 async.el   260     warning         Argument ‘args’ should appear (as ARGS) in the doc string (emacs-lisp-checkdoc)
 async.el   290     warning         Name emacs should appear capitalized as Emacs (emacs-lisp-checkdoc)
 async.el   371     warning         All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 async.el   380     warning         Argument ‘bindings’ should appear (as BINDINGS) in the doc string (emacs-lisp-checkdoc)
```