### PR TITLE
Replace deprecated cl require with cl-lib

### DIFF
--- a/async-test.el
+++ b/async-test.el
@@ -33,7 +33,7 @@
 
 
 (eval-when-compile
-  (require 'cl))
+  (require 'cl-lib))
 
 (defun async-test-1 ()
   (interactive)


### PR DESCRIPTION
(require 'cl) emits: Package cl is deprecated on emacs start,
replace it with cl-lib.