### PR TITLE
fix inclusion of bytecomp variables

### DIFF
--- a/async-bytecomp.el
+++ b/async-bytecomp.el
@@ -91,7 +91,7 @@ All *.elc files are systematically deleted before proceeding."
     (async-start
      `(lambda ()
         (require 'bytecomp)
-        ,(async-inject-variables "\\`\\(load-path\\)\\|byte\\'")
+        ,(async-inject-variables "\\`\\(load-path\\'\\|byte-\\)")
         (let ((default-directory (file-name-as-directory ,directory))
               error-data)
           (add-to-list 'load-path default-directory)

--- a/async-bytecomp.el
+++ b/async-bytecomp.el
@@ -91,7 +91,7 @@ All *.elc files are systematically deleted before proceeding."
     (async-start
      `(lambda ()
         (require 'bytecomp)
-        ,(async-inject-variables "\\`\\(load-path\\'\\|byte-\\)")
+        ,(async-inject-variables "\\`\\(?:load-path\\'\\|byte-\\)")
         (let ((default-directory (file-name-as-directory ,directory))
               error-data)
           (add-to-list 'load-path default-directory)


### PR DESCRIPTION
The regexp was inclusing all variables ending with `byte`, not variables starting with `byte-`.