### PR TITLE
Add GNU ELPA badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <p><a href="http://www.gnu.org/licenses/gpl-3.0.txt"><img src="https://img.shields.io/badge/license-GPL_3-green.svg" alt="License GPL 3" /></a>
+<a href="https://elpa.gnu.org/packages/async.html"><img src="https://elpa.gnu.org/packages/async.svg" alt="GNU ELPA" title="" /></a>
 <a href="http://melpa.org/#/async"><img src="http://melpa.org/packages/async-badge.svg" alt="MELPA" title="" /></a>
 <a href="http://stable.melpa.org/#/async"><img src="http://stable.melpa.org/packages/async-badge.svg" alt="MELPA Stable" title="" /></a></p>
 


### PR DESCRIPTION
GNU ELPA has badges now. This commit adds one to README.md.

You can see the badge here:
https://elpa.gnu.org/packages/async.svg

Thanks!