### PR TITLE
smtp async documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Set it to `'(all)` to be sure you will compile all packages asynchronously.
 
 ## Send mails asynchronously with smtp mail async
 
-To enable this feature, ensure smtp-mail-async.el is loaded and use
+To enable this feature, ensure smtpmail-async.el is loaded and use
 
 `(setq message-send-mail-function 'async-smtpmail-send-it)`.
 


### PR DESCRIPTION
Fixes the smtp-asyn documentation by pointing to the right .el file to load