### PR TITLE
Prevent inferior emacs from asking confirmation for large files

### DIFF
--- a/dired-async.el
+++ b/dired-async.el
@@ -377,6 +377,8 @@ ESC or `q' to not overwrite any of the remaining files,
        (async-start `(lambda ()
                        (require 'cl-lib) (require 'dired-aux) (require 'dired-x)
                        ,(async-inject-variables dired-async-env-variables-regexp)
+                       (advice-add #'files--ask-user-about-large-file
+                                   :override (lambda (&rest args) nil))
                        (let ((dired-recursive-copies (quote always))
                              (dired-copy-preserve-time
                               ,dired-copy-preserve-time)


### PR DESCRIPTION
Hello,

As mentioned by #111, when large files copies are attempted to remotes with some methods like ssh, the inferior emacs process never actually starts the copying and waits for ever for the user to confirm the copy (in the function `files--ask-user-about-large-file`, more specifically), with words to the effect : 

```
File is large, really copy ?
```

The solution offered, namely to merely use another method only works around the problem, does not solve it. In fact, since there is no obvious way to write to the standard input of the inferior emacs process, it should be prevented, as much as possible, to block waiting on some user interaction that will never occur (since the user cannot actually write anything to the inferior process). This is how I interpret the setting of the variable `create-dir` in the function `dired-async-create-files`.

So, this commit does not purport to eliminate all the possible ways the inferior emacs could block on user interaction, but eliminates at least the confirmation for large files, which is liable to happen.

There may be better ways to do this.

Best,

Aymeric