### PR TITLE
Add process filter to prompt for password or passphrase

### DIFF
--- a/async.el
+++ b/async.el
@@ -68,6 +68,8 @@ been setup so any async code can load libraries you expect.")
 ;; For emacs<29 (only exists in emacs-29+).
 (defvar print-symbols-bare)
 
+(defvar tramp-password-prompt-regexp)
+
 (defun async--purecopy (object)
   "Remove text properties in OBJECT.
 


### PR DESCRIPTION
At the moment, when the child emacs process needs to prompt the user for a password or a passphrase (for tramp, for instance), it hangs for ever.

This PR adds a very simple process filter and attaches it to the child process. I have taken inspiration from packages `dired-rsync` and `mu4e`, that also have to deal with child processes. It turns out that a process filter function is the canonical way to deal with prompts in child processes.

The process filter simply looks for a regular expression in the output of the child process. It it matches, the user is prompted in the parent emacs, and the password is then sent to the child, allowing it to terminate correctly.

The regexp has been chosen to match the output of ssh connection prompt with password or with passphrase-protected public key. Feel free to modify it to add more support cases !

This has been tested successfully.

This is a minimal working implementation. Feel free to ask me to improve it, particularly regarding documentation, variable naming, indentation, etc...

Best,

Aymeric Agon-Rambosson