### PR TITLE
Preserve value of async-prompt-for-password when async-start is called

### DIFF
--- a/async.el
+++ b/async.el
@@ -431,6 +431,7 @@ working directory."
       (set (make-local-variable 'async-callback) finish-func)
       (set (make-local-variable 'async-read-marker)
            (set-marker (make-marker) (point-min) buf))
+      (make-local-variable 'async-prompt-for-password)
       (set-marker-insertion-type async-read-marker nil)
 
       (set-process-sentinel proc #'async-when-done)


### PR DESCRIPTION
This allows callers of async-start to let-bind
async-prompt-for-password (e.g., to nil to prevent any prompting on data that might contain arbitrary sexps).  The value in effect while async-start is called is saved in the process's buffer, and is therefore used by async-read-from-client since it makes the process's buffer current.