### PR TITLE
New variable dired-async-large-file-warning-threshold

### DIFF
--- a/dired-async.el
+++ b/dired-async.el
@@ -81,6 +81,13 @@ or rename for `dired-async-skip-fast'."
   :risky t
   :type 'integer)
 
+(defcustom dired-async-large-file-warning-threshold large-file-warning-threshold
+  "Maximum size of file above which a confirmation for copy- 
+or rename-operations is requested. 
+   When nil, never request confirmation."
+  :type 'integer
+)
+
 (defface dired-async-message
     '((t (:foreground "yellow")))
   "Face used for mode-line message.")
@@ -245,8 +252,8 @@ cases if `dired-async-skip-fast' is non-nil."
 (defun dired-async--abort-if-file-too-large (size op-type filename)
   "If file SIZE larger than `large-file-warning-threshold', allow user to abort.
 Same as `abort-if-file-too-large' but without user-error."
-  (when (and large-file-warning-threshold size
-	     (> size large-file-warning-threshold))
+  (when (and dired-async-large-file-warning-threshold size
+	     (> size dired-async-large-file-warning-threshold))
     (files--ask-user-about-large-file
      size op-type filename nil)))
 

--- a/dired-async.el
+++ b/dired-async.el
@@ -250,8 +250,8 @@ cases if `dired-async-skip-fast' is non-nil."
                (nreverse quick-list) name-constructor marker-char))))
 
 (defun dired-async--abort-if-file-too-large (size op-type filename)
-  "If file SIZE larger than `large-file-warning-threshold', allow user to abort.
-Same as `abort-if-file-too-large' but without user-error."
+  "If file SIZE larger than `dired-async-large-file-warning-threshold', allow user to abort.
+Similar to `abort-if-file-too-large' but without user-error."
   (when (and dired-async-large-file-warning-threshold size
 	     (> size dired-async-large-file-warning-threshold))
     (files--ask-user-about-large-file


### PR DESCRIPTION
Fixes #185 
The user can now configure the size-threshold of files that trigger a confirmation when copying or moving/renaming, independently from the threshold used to trigger a confirmation when visiting files.