### PR TITLE
Add variable to set process-query-on-exit-flag

### DIFF
--- a/async.el
+++ b/async.el
@@ -50,6 +50,13 @@ When this is nil child Emacs will hang forever when a user interaction
 for password is required unless a password is stored in a \".authinfo\" file."
   :type 'boolean)
 
+(defvar async-process-noquery-on-exit nil
+  "Used as the :noquery argument to `make-process'.
+
+Intended to be let-bound around a call to `async-start' or
+`async-start-process'.  If non-nil, the child Emacs process will
+be silently killed if the user exits the parent Emacs.")
+
 (defvar async-debug nil)
 (defvar async-send-over-pipe t)
 (defvar async-in-child-emacs nil)
@@ -426,7 +433,8 @@ working directory."
                   :name name
                   :buffer buf
                   :stderr buf-err
-                  :command (cons program program-args)))))
+                  :command (cons program program-args)
+                  :noquery async-process-noquery-on-exit))))
     (set-process-sentinel
      (get-buffer-process buf-err)
      (lambda (proc _change)


### PR DESCRIPTION
This can't reliably be done by the caller of async-start, because
make-process will create an extra process for the stderr buffer that
cannot be easily found based on the returned process from async-start.

The new variable, async-process-query-on-exit-flag, can be let-bound
to nil around a call to async-start in order to cause the parent Emacs
to silently kill the child Emacs if the user quits the parent.

This can be useful for async processes run in timers for things like
notifications, where the user doesn't really care if a running process
actually finishes, since they're killing Emacs.