### PR TITLE
Specify custom group for async-package-message

### DIFF
--- a/async-package.el
+++ b/async-package.el
@@ -48,8 +48,9 @@
 The hook runs in the call-back once installation is done in child emacs.")
 
 (defface async-package-message
-    '((t (:foreground "yellow")))
-  "Face used for mode-line message.")
+  '((t (:foreground "yellow")))
+  "Face used for mode-line message."
+  :group 'async)
 
 (defun async-package-do-action (action packages error-file)
   "Execute ACTION asynchronously on PACKAGES.


### PR DESCRIPTION
The byte-compiler of Emacs 31 started warning about this.

```
  lib/async/async-package.el:50:10: Warning: in defface for
  ‘async-package-message’: fails to specify containing group
```