### PR TITLE
Ignore abbrev tables when injecting variables

### DIFF
--- a/async.el
+++ b/async.el
@@ -117,7 +117,7 @@ is returned unmodified."
                   collect elm))
         (t object)))
 
-(defvar async-inject-variables-exclude-regexps '("-syntax-table\\'")
+(defvar async-inject-variables-exclude-regexps '("-syntax-table\\'" "-abbrev-table\\'")
   "A list of regexps that `async-inject-variables' should ignore.")
 
 (defun async-inject-variables


### PR DESCRIPTION
This fixes variable injection in Emacs 30 since abbrev tables are not readable.
The issue occurs when async-inject-variables is called with an include regexp
that is the name of a major mode.